### PR TITLE
fix: guard against empty choices array in stream chunks

### DIFF
--- a/app/src/main/java/org/teslasoft/assistant/ui/activities/ChatActivity.kt
+++ b/app/src/main/java/org/teslasoft/assistant/ui/activities/ChatActivity.kt
@@ -2042,7 +2042,7 @@ class ChatActivity : FragmentActivity(), ChatAdapter.OnUpdateListener {
                 completions.flowOn(Dispatchers.IO).collect { v ->
                     run {
                         if (!currentCoroutineContext().isActive) throw CancellationException()
-                        else if (v.choices[0].delta != null && v.choices[0].delta?.content != null && v.choices[0].delta?.content.toString() != "null") {
+                        else if (v.choices.isNotEmpty() && v.choices[0].delta != null && v.choices[0].delta?.content != null && v.choices[0].delta?.content.toString() != "null") {
                             response += v.choices[0].delta?.content
                             if (response != "null") {
                                 messages[messages.size - 1]["message"] = response
@@ -2383,7 +2383,7 @@ class ChatActivity : FragmentActivity(), ChatAdapter.OnUpdateListener {
         completions.flowOn(Dispatchers.IO).collect { v ->
             run {
                 if (!currentCoroutineContext().isActive) throw CancellationException()
-                else if (v.choices[0].delta != null && v.choices[0].delta?.content != null && v.choices[0].delta?.content.toString() != "null") {
+                else if (v.choices.isNotEmpty() && v.choices[0].delta != null && v.choices[0].delta?.content != null && v.choices[0].delta?.content.toString() != "null") {
                     response += v.choices[0].delta?.content
                     messages[messages.size - 1]["message"] = response
                     if (messages.size > 2) {


### PR DESCRIPTION
Some OpenAI-compatible upstreams emit an initial streaming chunk with an empty `choices` array (e.g. as a preamble for content filter results) before sending any deltas. Accessing `choices[0]` on that chunk causes a crash:

```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
    at ey.b(SourceFile:33)
```

This adds an `isNotEmpty()` guard at both `collect` sites in `ChatActivity` before indexing into `choices`, so empty chunks are silently skipped.